### PR TITLE
Click to zoom photos + video

### DIFF
--- a/src/fixed-aspect.js
+++ b/src/fixed-aspect.js
@@ -1,0 +1,44 @@
+var html = require('nanohtml')
+var css = require('sheetify')
+
+var aspectStyle = css`
+:host {
+  position: relative;
+  height: 0;
+  overflow: hidden;
+  div, iframe, img {
+    position: absolute;
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: 100%;
+    object-fit: cover;
+  }
+}
+:host.aspect-16x9 {
+  padding-bottom: 56.25%;
+}
+:host.aspect-3x2 {
+  padding-bottom: 66.67%;
+}
+
+@media only screen and (max-width: 600px) {
+  :host {
+    width: 100vw;
+    left: -10px;
+  }
+  :host.aspect-16x9 {
+    padding-bottom: calc(56.25% + 11.25px);
+  }
+  :host.aspect-3x2 {
+    padding-bottom: calc(66.67% + 11.25px);
+  }
+}
+`
+
+const fixedAspect = (aspect, el) => html`
+<div class="${aspectStyle} aspect-${aspect}">
+  ${el}
+</div>`
+
+module.exports = fixedAspect

--- a/src/fixed-aspect.js
+++ b/src/fixed-aspect.js
@@ -12,6 +12,8 @@ var aspectStyle = css`
     left: 0;
     width: 100%;
     height: 100%;
+  }
+  img {
     object-fit: cover;
   }
 }

--- a/src/image.js
+++ b/src/image.js
@@ -51,6 +51,7 @@ ZoomableImage.prototype.zoomin = function () {
   })
   var zoomedImgUrl = RESIZE_URL + dim[0] + '/' + dim[1] + '/70/' + this.url
   var zoomedImg = new Image()
+  zoomedImg.crossOrigin = 'anonymous'
   zoomedImg.onload = function () {
     self.img.src = zoomedImgUrl
   }

--- a/src/image.js
+++ b/src/image.js
@@ -1,0 +1,155 @@
+/* global Image */
+
+var Nanocomponent = require('nanocomponent')
+var html = require('nanohtml')
+var css = require('sheetify')
+
+var fixedAspect = require('./fixed-aspect')
+
+var shadeClass = css`
+  :host {
+    transition: background-color 200ms ease-out;
+    transform: translateZ(0);
+    will-change: background-color;
+    z-index: 2;
+    background-color: rgba(0,0,0,0);
+    cursor: zoom-out;
+    position: fixed !important;
+  }
+  :host.zoomed {
+    background-color: rgba(0,0,0,0.8);
+  }
+`
+
+var imageClass = css`
+  :host {
+    cursor: zoom-in;
+    will-change: width,height,top,bottom;
+  }
+`
+
+const RESIZE_URL = 'https://resizer.digital-democracy.org/'
+
+module.exports = ZoomableImage
+
+function ZoomableImage () {
+  if (!(this instanceof ZoomableImage)) return new ZoomableImage()
+  this.zoomin = this.zoomin.bind(this)
+  this.zoomout = this.zoomout.bind(this)
+  this.removeShade = this.removeShade.bind(this)
+  this.returnInline = this.returnInline.bind(this)
+  Nanocomponent.call(this)
+}
+
+ZoomableImage.prototype = Object.create(Nanocomponent.prototype)
+
+ZoomableImage.prototype.zoomin = function () {
+  var self = this
+  this.img.addEventListener('mousewheel', noscroll)
+  var dim = getViewport().map(function (n) {
+    return n * window.devicePixelRatio
+  })
+  var zoomedImgUrl = RESIZE_URL + dim[0] + '/' + dim[1] + '/70/' + this.url
+  var zoomedImg = new Image()
+  zoomedImg.onload = function () {
+    self.img.src = zoomedImgUrl
+  }
+  zoomedImg.src = zoomedImgUrl
+  var rect = this.element.getBoundingClientRect()
+  Object.assign(this.img.style, {
+    top: rect.top + 'px',
+    left: rect.left + 'px',
+    width: rect.width + 'px',
+    height: rect.height + 'px',
+    position: 'fixed',
+    transform: 'translateZ(0)',
+    zIndex: 9999
+  })
+  this.element.insertBefore(this.shade, this.img)
+  setTimeout(function () {
+    self.shade.classList.add('zoomed')
+    self.img.onclick = self.zoomout
+    Object.assign(self.img.style, {
+      transition: 'all 200ms ease-out',
+      objectFit: 'contain',
+      top: 0,
+      left: 0,
+      width: '100%',
+      height: '100%'
+    })
+  }, 20)
+}
+
+ZoomableImage.prototype.zoomout = function () {
+  this.shade.classList.remove('zoomed')
+  this.shade.addEventListener('transitionend', this.removeShade)
+  this.img.addEventListener('transitionend', this.returnInline)
+  var rect = this.element.getBoundingClientRect()
+  Object.assign(this.img.style, {
+    top: rect.top + 'px',
+    left: rect.left + 'px',
+    width: rect.width + 'px',
+    height: rect.height + 'px'
+  })
+}
+
+ZoomableImage.prototype.removeShade = function () {
+  this.shade.removeEventListener('transitionend', this.removeShade)
+  if (!this.shade.parentNode) return
+  this.shade.parentNode.removeChild(this.shade)
+}
+
+ZoomableImage.prototype.returnInline = function () {
+  this.img.removeEventListener('transitionend', this.returnInline)
+  this.img.removeEventListener('mousewheel', noscroll)
+  this.img.onclick = this.zoomin
+  Object.assign(this.img.style, {
+    objectFit: 'cover',
+    transition: 'none',
+    transform: null,
+    top: 0,
+    left: 0,
+    width: '100%',
+    height: '100%',
+    cursor: 'zoom-in',
+    position: null,
+    zIndex: 0
+  })
+}
+
+ZoomableImage.prototype.createElement = function (url) {
+  this.url = url
+  var src = RESIZE_URL + '400/400/20/' + url
+  this.img = html`<img class=${imageClass} crossorigin="anonymous" onclick=${this.zoomin} src=${src} />`
+  this.shade = html`<div class=${shadeClass} />`
+  this.shade.onclick = this.zoomout
+  return fixedAspect('3x2', this.img)
+}
+
+ZoomableImage.prototype.update = function (url) {
+  return this.url !== url
+}
+
+ZoomableImage.prototype.load = function (el) {
+  var responsiveImg = new Image()
+  var img = this.img
+  // Get image width rounded to nearest 100
+  var width = Math.ceil(img.width / 100) * 100 * window.devicePixelRatio
+  var imageUrl = RESIZE_URL + width + '/' + this.url
+  responsiveImg.crossOrigin = 'anonymous'
+  responsiveImg.onload = function () {
+    img.src = imageUrl
+  }
+  responsiveImg.src = imageUrl
+}
+
+function getViewport () {
+  var w = Math.max(document.documentElement.clientWidth, window.innerWidth || 0)
+  var h = Math.max(document.documentElement.clientHeight, window.innerHeight || 0)
+  return [w, h]
+}
+
+function noscroll (e) {
+  e.stopPropagation()
+  e.preventDefault()
+}

--- a/src/image.js
+++ b/src/image.js
@@ -136,7 +136,7 @@ ZoomableImage.prototype.load = function (el) {
   var responsiveImg = new Image()
   var img = this.img
   // Get image width rounded to nearest 100
-  var width = Math.ceil(img.width / 100) * 100 * window.devicePixelRatio
+  var width = Math.ceil(this.element.clientWidth / 100) * 100 * window.devicePixelRatio
   var imageUrl = RESIZE_URL + width + '/' + this.url
   responsiveImg.crossOrigin = 'anonymous'
   responsiveImg.onload = function () {

--- a/src/image.js
+++ b/src/image.js
@@ -68,6 +68,7 @@ ZoomableImage.prototype.zoomin = function () {
   })
   this.element.insertBefore(this.shade, this.img)
   setTimeout(function () {
+    self.img.style.cursor = 'zoom-out'
     self.shade.classList.add('zoomed')
     self.img.onclick = self.zoomout
     Object.assign(self.img.style, {

--- a/src/image.js
+++ b/src/image.js
@@ -45,10 +45,12 @@ ZoomableImage.prototype = Object.create(Nanocomponent.prototype)
 
 ZoomableImage.prototype.zoomin = function () {
   var self = this
-  disableScroll(this.img)
-  var dim = getViewport().map(function (n) {
+  var dim = getViewport()
+  if (dim[0] <= this.element.clientWidth) return
+  dim = dim.map(function (n) {
     return n * window.devicePixelRatio
   })
+  disableScroll(this.img)
   var zoomedImgUrl = RESIZE_URL + dim[0] + '/' + dim[1] + '/70/' + this.url
   var zoomedImg = new Image()
   zoomedImg.crossOrigin = 'anonymous'

--- a/src/image.js
+++ b/src/image.js
@@ -45,7 +45,7 @@ ZoomableImage.prototype = Object.create(Nanocomponent.prototype)
 
 ZoomableImage.prototype.zoomin = function () {
   var self = this
-  this.img.addEventListener('mousewheel', noscroll)
+  disableScroll(this.img)
   var dim = getViewport().map(function (n) {
     return n * window.devicePixelRatio
   })
@@ -103,7 +103,7 @@ ZoomableImage.prototype.removeShade = function () {
 
 ZoomableImage.prototype.returnInline = function () {
   this.img.removeEventListener('transitionend', this.returnInline)
-  this.img.removeEventListener('mousewheel', noscroll)
+  enableScroll(this.img)
   this.img.onclick = this.zoomin
   Object.assign(this.img.style, {
     objectFit: 'cover',
@@ -151,7 +151,18 @@ function getViewport () {
   return [w, h]
 }
 
-function noscroll (e) {
+function disableScroll (el) {
+  el.addEventListener('mousewheel', stopPropagation)
+  el.addEventListener('touchmove', stopPropagation)
+}
+
+function enableScroll (el) {
+  el.removeEventListener('mousewheel', stopPropagation)
+  el.removeEventListener('touchmove', stopPropagation)
+}
+
+function stopPropagation (e) {
   e.stopPropagation()
   e.preventDefault()
+  return false
 }

--- a/src/sidebar.js
+++ b/src/sidebar.js
@@ -1,10 +1,10 @@
-/* global Image */
-
 const css = require('sheetify')
-const Player = require('@vimeo/player')
 const html = require('nanohtml')
 const raw = require('nanohtml/raw')
 const onIntersectOrig = require('on-intersect')
+
+var ZoomableImage = require('./image')
+var ZoomableVideo = require('./video')
 
 function onIntersect () {
   if (typeof window === 'undefined') return
@@ -20,63 +20,7 @@ var translations = {
 
 var mapTransition = require('./map_transition')
 
-const RESIZE_URL = 'https://resizer.digital-democracy.org/'
 const IMAGE_URL = 'https://images.digital-democracy.org/waorani-images/'
-
-var aspectStyle = css`
-  .center {
-    text-align: center;
-  }
-  :host {
-    width: 100%;
-    position: relative;
-  }
-  :host.aspect-16x9 {
-    padding-bottom: 56.25%;
-  }
-  :host.aspect-3x2 {
-    padding-bottom: 66.67%;
-  }
-  :host > div {
-    position: absolute;
-    top: 0;
-    bottom: 0;
-    left: 0;
-    right: 0;
-  }
-  img {
-    width: 100%;
-    height: 100%;
-  }
-  @media only screen and (max-width: 600px) {
-    :host {
-      width: 100vw;
-      left: -10px;
-    }
-    :host.aspect-16x9 {
-      padding-bottom: calc(56.25% + 11.25px);
-    }
-    :host.aspect-3x2 {
-      padding-bottom: calc(66.67% + 11.25px);
-    }
-  }
-`
-
-var videoDivStyle = css`
-  :host {
-    background-position: center;
-    background-size: cover;
-    background-color: black;
-  }
-`
-
-function aspectDiv (aspect, el) {
-  return html`<div class="${aspectStyle} aspect-${aspect}">
-    <div>
-      ${el}
-    </div>
-  </div>`
-}
 
 function mapView (id, onenter, el) {
   // Don't consider title in map view until more than 40% from bottom
@@ -91,90 +35,35 @@ function mapView (id, onenter, el) {
 }
 
 function video (url, opts) {
-  // TODO: create placeholder images for videos
-  if (!opts) opts = {}
-  var options = Object.assign({
+  return ZoomableVideo().render({
+    placeholder: IMAGE_URL + opts.placeholderImg,
     url: url,
-    background: true,
-    autoplay: true,
-    muted: false,
-    loop: true,
-    title: false,
-    portrait: false,
-    byline: false
-  }, opts)
-  var previewUrl = RESIZE_URL + '400/400/20/' + IMAGE_URL + opts.placeholderImg
-  var el = html`
-  <div class=${videoDivStyle} style="background-image: url(${previewUrl});">
-  </div>`
-  var player
-
-  // var muted = true
-  onIntersect(el, onenter, onexit)
-
-  // function toggleMute () {
-  //   if (!player) return
-  //   player.ready().then(function () {
-  //     return player.setVolume(muted ? 1 : 0)
-  //   }).then(function () {
-  //     muted = !muted
-  //   })
-  // }
-
-  function onenter () {
-    var img = new Image()
-    // Get image width rounded to nearest 100
-    var width = Math.ceil(el.offsetWidth / 100) * 100 * window.devicePixelRatio
-    var imageUrl = RESIZE_URL + width + '/' + IMAGE_URL + opts.placeholderImg
-    img.crossOrigin = 'anonymous'
-    img.src = imageUrl
-    img.onload = function () {
-      el.style['background-image'] = 'url(' + imageUrl + ')'
-    }
-    player = new Player(el, options)
-    player.element.style.width = '100%'
-    player.element.style.height = '100%'
-    if (options.background) player.setCurrentTime(2)
-  }
-
-  function onexit () {
-    player.destroy()
-  }
-  return aspectDiv('16x9', el)
+    background: opts.background
+  })
 }
 
 function image (path) {
-  var hasBeenSeen = false
-  var previewUrl = RESIZE_URL + '400/400/20/' + IMAGE_URL + path + '.jpg'
-  var el = html`<img crossorigin="anonymous" src=${previewUrl} />`
-
-  onIntersect(el, function () {
-    if (hasBeenSeen) return
-    var img = new Image()
-    // Get image width rounded to nearest 100
-    var width = Math.ceil(el.width / 100) * 100 * window.devicePixelRatio
-    var imageUrl = RESIZE_URL + width + '/' + IMAGE_URL + path + '.jpg'
-    img.crossOrigin = 'anonymous'
-    img.src = imageUrl
-    img.onload = function () {
-      el.src = imageUrl
-    }
-    hasBeenSeen = true
-  })
-
-  return aspectDiv('3x2', el)
+  return ZoomableImage().render(IMAGE_URL + path + '.jpg')
 }
 
 var style = css`
   :host {
     width: 100%;
     position: fixed;
-    overflow-y: scroll;
-    -webkit-overflow-scrolling: touch;
-    max-height: 100%;
+    z-index: 2;
+    height: 100%;
+    overflow: hidden;
     transform: translateZ(0);
+    #scroll-container {
+      overflow-y: scroll;
+      -webkit-overflow-scrolling: touch;
+      position: absolute;
+      top: 0;
+      left: 0;
+      width: 100%;
+      height: 100%
+    }
     #sidebar {
-      transform: translateZ(0);
       z-index: 999;
       color: white;
       section {
@@ -191,16 +80,6 @@ var style = css`
         flex-direction: column;
         justify-content: flex-end;
         padding-bottom: 0;
-      }
-      img {
-        max-width: 100%;
-      }
-      video {
-        max-width: 100%;
-      }
-      iframe {
-        width: 100%;
-        height: 100%;
       }
       .caption {
         text-align: left;
@@ -278,8 +157,7 @@ var style = css`
     :host {
       background: linear-gradient(to right, rgba(22,22,22, .6), rgba(22,22,22, .4) 40%, rgba(22,22,22, .2) 60%, transparent 70%);
       #sidebar {
-        margin-right: -16px;
-        margin-left: 20px;
+        padding-left: 20px;
         width: 45%;
         max-width: 600px;
       }
@@ -303,10 +181,13 @@ module.exports = function (lang, _map) {
   }
 
   return html`<div id="sidebar-wrapper" class=${style}>
-  <div id="sidebar">
+  <div id="scroll-container">
+    <div id="sidebar">
       <section>
         ${mapView('start', onview, html`<h1>${message('title')}</h1>`)}
-        ${video('https://vimeo.com/270209852/d857a916b5', {placeholderImg: '1territory.jpg'})}
+        ${video('https://vimeo.com/270209852/d857a916b5', {
+          background: true,
+          placeholderImg: '1territory.jpg'})}
         <p>${message('start')}</p>
       </section>
       <section>
@@ -317,7 +198,9 @@ module.exports = function (lang, _map) {
         ${mapView('oil-rush', onview, html`<h2>${message('oil-rush-title')}</h2>`)}
         ${image('2a')}
         <p>${message('oil-rush')}</p>
-        ${video('https://vimeo.com/270208622/ee7d7a12cc', {placeholderImg: '2oil.jpg'})}
+        ${video('https://vimeo.com/270208622/ee7d7a12cc', {
+          background: true,
+          placeholderImg: '2oil.jpg'})}
       </section>
       <section>
         ${mapView('maps-and-resistance', onview, html`<h2>${message('maps-and-resistance-title')}</h2>`)}
@@ -330,7 +213,9 @@ module.exports = function (lang, _map) {
       <section>
         ${mapView('wildlife', onview, html`<h2>${message('at-stake')}</h2>`)}
         <h3>${message('wildlife-title')}</h3>
-        ${video('https://vimeo.com/270211119/a857892d50', {placeholderImg: '3wildlife.jpg'})}
+        ${video('https://vimeo.com/270211119/a857892d50', {
+          background: true,
+          placeholderImg: '3wildlife.jpg'})}
         <p>${message('wildlife')}</p>
         ${image('4WildlifeB')}
       </section>
@@ -342,7 +227,9 @@ module.exports = function (lang, _map) {
       </section>
       <section>
         ${mapView('culture', onview, html`<h3>${message('living-title')}</h3>`)}
-        ${video('https://vimeo.com/270211741/575052a044', {background: false, placeholderImg: '4chant.jpg'})}
+        ${video('https://vimeo.com/270211741/575052a044', {
+          background: false,
+          placeholderImg: '4chant.jpg'})}
         <p>${message('living')}</p>
         ${image('6CultureB')}
       </section>
@@ -360,7 +247,9 @@ module.exports = function (lang, _map) {
         <p>
         ${message('testimony-caption')}</p>
         <p>
-        ${video('https://vimeo.com/270212698/62b62abe89', {background: false, placeholderImg: '5testimonies.jpg'})}
+        ${video('https://vimeo.com/270212698/62b62abe89', {
+          background: false,
+          placeholderImg: '5testimonies.jpg'})}
         </p>
         <div class='center'>
           <h2>${message('final-title')}</h2>
@@ -376,6 +265,6 @@ module.exports = function (lang, _map) {
         </div>
       </section>
     </div>
-    </div>
-    `
+  </div>
+  </div>`
 }

--- a/src/sidebar.js
+++ b/src/sidebar.js
@@ -147,9 +147,9 @@ var style = css`
   @media only screen and (max-width: 600px) {
     :host {
       background: black;
-      padding: 10px;
-      #sidebar {
-        width: 95%;
+      #scroll-container {
+        padding: 10px;
+        box-sizing: border-box;
       }
     }
   }
@@ -159,6 +159,7 @@ var style = css`
       #sidebar {
         padding-left: 20px;
         width: 45%;
+        box-sizing: border-box;
         max-width: 600px;
       }
     }

--- a/src/video.js
+++ b/src/video.js
@@ -62,7 +62,7 @@ ZoomableVideo.prototype = Object.create(Nanocomponent.prototype)
 ZoomableVideo.prototype.zoomin = function () {
   this.shade.removeEventListener('transitionend', this.removeShade)
   this.wrapperDiv.removeEventListener('transitionend', this.returnInline)
-  this.wrapperDiv.addEventListener('mousewheel', noscroll)
+  disableScroll(this.wrapperDiv)
   var self = this
   var wrapperDiv = this.wrapperDiv
   var rect = this.element.getBoundingClientRect()
@@ -114,7 +114,7 @@ ZoomableVideo.prototype.removeShade = function () {
 
 ZoomableVideo.prototype.returnInline = function () {
   this.wrapperDiv.removeEventListener('transitionend', this.returnInline)
-  this.wrapperDiv.removeEventListener('mousewheel', noscroll)
+  enableScroll(this.wrapperDiv)
   this.wrapperDiv.onclick = this.zoomin
   if (this.iframe) this.iframe.style.transform = null
   Object.assign(this.wrapperDiv.style, {
@@ -172,7 +172,18 @@ ZoomableVideo.prototype.update = function () {
   return false
 }
 
-function noscroll (e) {
+function disableScroll (el) {
+  el.addEventListener('mousewheel', stopPropagation)
+  el.addEventListener('touchmove', stopPropagation)
+}
+
+function enableScroll (el) {
+  el.removeEventListener('mousewheel', stopPropagation)
+  el.removeEventListener('touchmove', stopPropagation)
+}
+
+function stopPropagation (e) {
   e.stopPropagation()
   e.preventDefault()
+  return false
 }

--- a/src/video.js
+++ b/src/video.js
@@ -71,13 +71,13 @@ ZoomableVideo.prototype.zoomin = function () {
   wrapperDiv.style.cursor = 'zoom-out'
   self.shade.onclick = self.zoomout
   if (!this.background && this.player) this.player.play()
+  if (this.iframe) this.iframe.style.transform = 'translateZ(0)'
   Object.assign(wrapperDiv.style, {
     top: rect.top + 'px',
     left: rect.left + 'px',
     width: rect.width + 'px',
     height: rect.height + 'px',
     position: 'fixed',
-    transform: 'translateZ(0)',
     zIndex: 9999
   })
   setTimeout(function () {
@@ -116,6 +116,7 @@ ZoomableVideo.prototype.returnInline = function () {
   this.wrapperDiv.removeEventListener('transitionend', this.returnInline)
   this.wrapperDiv.removeEventListener('mousewheel', noscroll)
   this.wrapperDiv.onclick = this.zoomin
+  if (this.iframe) this.iframe.style.transform = null
   Object.assign(this.wrapperDiv.style, {
     transition: 'none',
     transform: null,
@@ -136,6 +137,7 @@ ZoomableVideo.prototype.onenter = function () {
   })
   this.player.ready().then(() => {
     this.wrapperDiv.style.backgroundSize = 0
+    this.iframe = this.wrapperDiv.childNodes[0]
   })
   if (this.background) this.player.setCurrentTime(2)
 }
@@ -143,6 +145,7 @@ ZoomableVideo.prototype.onenter = function () {
 ZoomableVideo.prototype.onexit = function exit () {
   this.wrapperDiv.style.backgroundSize = 'cover'
   this.player.destroy()
+  this.iframe = null
 }
 
 ZoomableVideo.prototype.createElement = function (props) {

--- a/src/video.js
+++ b/src/video.js
@@ -60,6 +60,8 @@ function ZoomableVideo () {
 ZoomableVideo.prototype = Object.create(Nanocomponent.prototype)
 
 ZoomableVideo.prototype.zoomin = function () {
+  var dim = getViewport()
+  if (dim[0] <= this.element.clientWidth) return
   this.shade.removeEventListener('transitionend', this.removeShade)
   this.wrapperDiv.removeEventListener('transitionend', this.returnInline)
   disableScroll(this.wrapperDiv)
@@ -170,6 +172,12 @@ ZoomableVideo.prototype.beforerender = function (el) {
 
 ZoomableVideo.prototype.update = function () {
   return false
+}
+
+function getViewport () {
+  var w = Math.max(document.documentElement.clientWidth, window.innerWidth || 0)
+  var h = Math.max(document.documentElement.clientHeight, window.innerHeight || 0)
+  return [w, h]
 }
 
 function disableScroll (el) {

--- a/src/video.js
+++ b/src/video.js
@@ -1,0 +1,175 @@
+var Nanocomponent = require('nanocomponent')
+var html = require('nanohtml')
+var css = require('sheetify')
+const onIntersectOrig = require('on-intersect')
+const Player = require('@vimeo/player')
+
+var fixedAspect = require('./fixed-aspect')
+
+function onIntersect () {
+  if (typeof window === 'undefined') return
+  onIntersectOrig.apply(null, arguments)
+}
+
+var videoDivClass = css`
+  :host {
+    background-position: center;
+    background-size: contain;
+    will-change: width,height,top,bottom;
+    cursor: zoom-in;
+    user-select: none;
+    background-size: contain;
+    background-repeat: no-repeat;
+    background-position: center;
+  }
+  :host iframe {
+    pointer-events: none;
+  }
+`
+
+var shadeClass = css`
+  :host {
+    transition: background-color 200ms ease-out;
+    transform: translateZ(0);
+    will-change: background-color;
+    z-index: 2;
+    background-color: rgba(0,0,0,0);
+    cursor: zoom-out;
+    position: fixed !important;
+  }
+  :host.zoomed {
+    background-color: rgba(0,0,0,0.8);
+  }
+`
+
+const RESIZE_URL = 'https://resizer.digital-democracy.org/'
+
+module.exports = ZoomableVideo
+
+function ZoomableVideo () {
+  if (!(this instanceof ZoomableVideo)) return new ZoomableVideo()
+  this.onenter = this.onenter.bind(this)
+  this.onexit = this.onexit.bind(this)
+  this.zoomin = this.zoomin.bind(this)
+  this.zoomout = this.zoomout.bind(this)
+  this.removeShade = this.removeShade.bind(this)
+  this.returnInline = this.returnInline.bind(this)
+  Nanocomponent.call(this)
+}
+
+ZoomableVideo.prototype = Object.create(Nanocomponent.prototype)
+
+ZoomableVideo.prototype.zoomin = function () {
+  this.shade.removeEventListener('transitionend', this.removeShade)
+  this.wrapperDiv.removeEventListener('transitionend', this.returnInline)
+  this.wrapperDiv.addEventListener('mousewheel', noscroll)
+  var self = this
+  var wrapperDiv = this.wrapperDiv
+  var rect = this.element.getBoundingClientRect()
+  this.element.insertBefore(this.shade, wrapperDiv)
+  wrapperDiv.onclick = self.zoomout
+  wrapperDiv.style.cursor = 'zoom-out'
+  self.shade.onclick = self.zoomout
+  if (!this.background && this.player) this.player.play()
+  Object.assign(wrapperDiv.style, {
+    top: rect.top + 'px',
+    left: rect.left + 'px',
+    width: rect.width + 'px',
+    height: rect.height + 'px',
+    position: 'fixed',
+    transform: 'translateZ(0)',
+    zIndex: 9999
+  })
+  setTimeout(function () {
+    self.shade.classList.add('zoomed')
+    Object.assign(wrapperDiv.style, {
+      transition: 'all 200ms ease-out',
+      top: 0,
+      left: 0,
+      width: '100%',
+      height: '100%'
+    })
+  }, 20)
+}
+
+ZoomableVideo.prototype.zoomout = function () {
+  this.shade.classList.remove('zoomed')
+  this.shade.addEventListener('transitionend', this.removeShade)
+  this.wrapperDiv.addEventListener('transitionend', this.returnInline)
+  var rect = this.element.getBoundingClientRect()
+  if (!this.background && this.player) this.player.pause()
+  Object.assign(this.wrapperDiv.style, {
+    top: rect.top + 'px',
+    left: rect.left + 'px',
+    width: rect.width + 'px',
+    height: rect.height + 'px'
+  })
+}
+
+ZoomableVideo.prototype.removeShade = function () {
+  this.shade.removeEventListener('transitionend', this.removeShade)
+  if (!this.shade.parentNode) return
+  this.shade.parentNode.removeChild(this.shade)
+}
+
+ZoomableVideo.prototype.returnInline = function () {
+  this.wrapperDiv.removeEventListener('transitionend', this.returnInline)
+  this.wrapperDiv.removeEventListener('mousewheel', noscroll)
+  this.wrapperDiv.onclick = this.zoomin
+  Object.assign(this.wrapperDiv.style, {
+    transition: 'none',
+    transform: null,
+    top: 0,
+    left: 0,
+    width: '100%',
+    height: '100%',
+    cursor: 'zoom-in',
+    position: null,
+    zIndex: 0
+  })
+}
+
+ZoomableVideo.prototype.onenter = function () {
+  this.player = new Player(this.wrapperDiv, {
+    url: this.url,
+    background: this.background
+  })
+  this.player.ready().then(() => {
+    this.wrapperDiv.style.backgroundSize = 0
+  })
+  if (this.background) this.player.setCurrentTime(2)
+}
+
+ZoomableVideo.prototype.onexit = function exit () {
+  this.wrapperDiv.style.backgroundSize = 'cover'
+  this.player.destroy()
+}
+
+ZoomableVideo.prototype.createElement = function (props) {
+  this.url = props.url
+  this.placeholder = props.placeholder
+  this.background = props.background
+  var placeholderUrl = RESIZE_URL + '400/400/20/' + this.placeholder
+  this.wrapperDiv = html`<div
+    class=${videoDivClass}
+    style="background-image: url(${placeholderUrl});"
+    onclick=${this.zoomin} />`
+  this.aspectDiv = fixedAspect('16x9', this.wrapperDiv)
+  this.shade = html`<div
+    onclick=${this.zoomout}
+    class=${shadeClass} />`
+  return this.aspectDiv
+}
+
+ZoomableVideo.prototype.beforerender = function (el) {
+  onIntersect(el, this.onenter, this.onexit)
+}
+
+ZoomableVideo.prototype.update = function () {
+  return false
+}
+
+function noscroll (e) {
+  e.stopPropagation()
+  e.preventDefault()
+}

--- a/src/video.js
+++ b/src/video.js
@@ -61,7 +61,12 @@ ZoomableVideo.prototype = Object.create(Nanocomponent.prototype)
 
 ZoomableVideo.prototype.zoomin = function () {
   var dim = getViewport()
-  if (dim[0] <= this.element.clientWidth) return
+  if (dim[0] <= this.element.clientWidth) {
+    if (!this.background && this.player) {
+      this.player.play()
+    }
+    return
+  }
   this.shade.removeEventListener('transitionend', this.removeShade)
   this.wrapperDiv.removeEventListener('transitionend', this.returnInline)
   disableScroll(this.wrapperDiv)
@@ -135,7 +140,8 @@ ZoomableVideo.prototype.returnInline = function () {
 ZoomableVideo.prototype.onenter = function () {
   this.player = new Player(this.wrapperDiv, {
     url: this.url,
-    background: this.background
+    background: this.background,
+    playsinline: this.background
   })
   this.player.ready().then(() => {
     this.wrapperDiv.style.backgroundSize = 0

--- a/static/index.html
+++ b/static/index.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset='utf-8' />
   <title>Our Rainforest Is Not For Sale</title>
-  <meta name='viewport' content='initial-scale=1,maximum-scale=1,user-scalable=no' />
+  <meta name='viewport' content='width=device-width,initial-scale=1,maximum-scale=1,user-scalable=no' />
   <link href="https://fonts.googleapis.com/css?family=Nunito+Sans" rel="stylesheet">
   <link href="bundle.css" rel="stylesheet">
   <style type="text/css">
@@ -19,6 +19,7 @@
       }
     }
     body, html {
+      -webkit-text-size-adjust: 100%; /* Prevent font scaling in landscape while allowing user zoom */
       overflow: hidden;
       top: 0;
       bottom: 0;


### PR DESCRIPTION
Given the beauty of the photos and video, it seemed a shame that they were only visible small. This PR adds a click-to-zoom functionality to zoom photos and video to fullscreen.

For videos with audio (ie non-background videos which do not autoplay), clicking will both zoom and play, and clicking again will zoomout and pause.