### PR TITLE
fix: replace polyfill.io with Cloudflare version

### DIFF
--- a/bin/inject-cache-warmer
+++ b/bin/inject-cache-warmer
@@ -12,7 +12,7 @@ var config = require('../mapbox-config')
 
 var cachableUrls = [
   'https://fonts.googleapis.com/css?family=Nunito+Sans',
-  'https://polyfill.io/v2/polyfill.min.js?features=IntersectionObserver',
+  'https://cdnjs.cloudflare.com/polyfill/v3/polyfill.min.js?features=IntersectionObserver',
   'https://api.tiles.mapbox.com/mapbox-gl-js/v0.45.0/mapbox-gl.css',
   'https://api.tiles.mapbox.com/mapbox-gl-js/v0.45.0/mapbox-gl.js'
 ]

--- a/static/index.html
+++ b/static/index.html
@@ -48,7 +48,7 @@
 <body>
 <div id='map'></div>
 <div id='sidebar-wrapper'></div>
-<script src="https://polyfill.io/v2/polyfill.min.js?features=IntersectionObserver"></script>
+<script src="https://cdnjs.cloudflare.com/polyfill/v3/polyfill.min.js?features=IntersectionObserver"></script>
 <script src='bundle.js'></script>
 </body>
 </html>


### PR DESCRIPTION
This replaces references to `polyfill.io`, [which is now malware][0], with [Cloudflare's version][1].

Note that we were using `/v2` of `polyfill.io` and are now using `/v3` of the Cloudflare API. I think this is fine, but wanted to flag.

*I did not test this manually.*

[0]: https://www.theregister.com/2024/06/25/polyfillio_china_crisis/
[1]: https://blog.cloudflare.com/automatically-replacing-polyfill-io-links-with-cloudflares-mirror-for-a-safer-internet